### PR TITLE
Bump version to 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theharithsa/dynatrace-mcp-server",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Dynatrace Model Context Protocol (MCP) Server for AI assistants",
   "main": "./dist/index.js",
   "type": "commonjs",


### PR DESCRIPTION
This pull request includes a version bump for the `@theharithsa/dynatrace-mcp-server` package in the `package.json` file, updating it from version `2.0.1` to `2.0.2`.